### PR TITLE
removes base contract dependency on hardhat / fixes initializer modifiers

### DIFF
--- a/contracts/ERC3525Upgradeable.sol
+++ b/contracts/ERC3525Upgradeable.sol
@@ -87,7 +87,7 @@ abstract contract ERC3525Upgradeable is
 
     /// @notice Contract initialization logic
     // solhint-disable-next-line func-name-mixedcase
-    function __ERC3525Upgradeable_init() public initializer {
+    function __ERC3525Upgradeable_init() public onlyInitializing {
         tokenCounter = 0;
     }
 

--- a/contracts/ERC3525Upgradeable.sol
+++ b/contracts/ERC3525Upgradeable.sol
@@ -10,8 +10,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721Enume
 import "./interfaces/IERC3525MetadataUpgradeable.sol";
 import "./interfaces/IERC3525Receiver.sol";
 
-import "hardhat/console.sol";
-
 error NonExistentToken(uint256 tokenId);
 error NonExistentSlot(uint256 slotId);
 error InsufficientBalance(uint256 transferAmount, uint256 balance);


### PR DESCRIPTION
Since this is a base primitive I wouldn't recommend to make it dependent on hardhat. The code itself doesn't explicitly use any log directive anyhow (and it breaks when used inside a foundry setup :) )

Also replaced `initializer` with the `onlyInitializing` modifier in the base ERC3525 primitive which essentially guards the function the same way as before but allows it to be deployed in an UUPS context. See OZ's token primitives as a reference: 

 https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/token/ERC721/ERC721Upgradeable.sol#L45 or 
 https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/token/ERC1155/ERC1155Upgradeable.sol#L36