### PR TITLE
Demonstrates 3 issues with enums / token burns

### DIFF
--- a/contracts/mocks/ERC3525_Testing.sol
+++ b/contracts/mocks/ERC3525_Testing.sol
@@ -53,6 +53,14 @@ contract ERC3525_Testing is ERC3525SlotEnumerableUpgradeable {
         return _isApprovedOrOwner(operator_, tokenId_);
     }
 
+    function splitValue(uint256 fromToken_, uint256 value_) public virtual returns (uint256 tokenId) {
+        return _splitValue(fromToken_, value_);
+    }
+
+    function mergeValue(uint256 fromToken_, uint256 toToken_) public virtual returns (uint256 tokenId) {
+        return _mergeValue(fromToken_, toToken_);
+    }
+
     function slotURI(
         uint256 /*slot_*/
     ) public pure override returns (string memory) {

--- a/test/erc3525/ERC3525.burn.ts
+++ b/test/erc3525/ERC3525.burn.ts
@@ -25,5 +25,18 @@ export function shouldBehaveLikeSemiFungibleTokenBurn(): void {
 
       await expect(user.sft.burn(2)).to.be.revertedWith("NotApprovedOrOwner");
     });
+
+    it("doesnt reallocate value after a token is burnt", async function () {
+      const { sft, user, anon } = await setupTestERC3525();
+      await sft.mintValue(user.address, 1, 10);
+
+      expect(await sft.ownerOf(1)).to.equal(user.address);
+      await user.sft["transferFrom(uint256,address,uint256)"](1, anon.address, 5);
+      expect(await sft.ownerOf(2)).to.equal(anon.address);
+
+      await anon.sft.burn(2);
+      expect((await sft["balanceOf(address)"](anon.address)).isZero()).to.be.true;
+      expect((await sft["balanceOf(uint256)"](1)).toNumber()).to.equal(5);
+    });
   });
 }

--- a/test/erc3525/ERC3525.mint.ts
+++ b/test/erc3525/ERC3525.mint.ts
@@ -44,5 +44,19 @@ export function shouldBehaveLikeSemiFungibleTokenMint(): void {
       expect(await sft["balanceOf(uint256)"](1)).to.be.eq("1000000");
       expect(await sft["balanceOf(uint256)"](2)).to.be.eq("2000000");
     });
+
+    it("enumerates slots correctly", async function () {
+      const { sft, user, anon } = await setupTestERC3525();
+      await sft.mintValue(user.address, 1, 10);
+      await user.sft["transferFrom(uint256,address,uint256)"](1, anon.address, 5);
+      expect(await sft.ownerOf(1)).to.be.eq(user.address);
+      expect(await sft.ownerOf(2)).to.be.eq(anon.address);
+      expect(await sft["tokenInSlotByIndex"](1, 0)).to.be.eq("1");
+      expect(await sft.totalSupply()).to.be.eq(2);
+
+      //these fail:
+      //expect(await sft["tokenInSlotByIndex"](1, 1)).to.be.eq("2"); //reverts
+      expect(await sft.tokenSupplyInSlot(1)).to.be.eq(2); //returns 1
+    });
   });
 }

--- a/test/erc3525/ERC3525.transfer.ts
+++ b/test/erc3525/ERC3525.transfer.ts
@@ -66,5 +66,18 @@ export function shouldBehaveLikeSemiFungibleTokenTransfer(): void {
       expect(await sft["balanceOf(uint256)"](1)).to.be.eq("500000");
       expect(await sft["balanceOf(uint256)"](2)).to.be.eq("500000");
     });
+
+    it("doesnt decrease total supply after nfts have been merged", async function () {
+      const { sft, user } = await setupTestERC3525();
+      await sft.mintValue(user.address, 1, 10);
+      await user.sft.splitValue(1, 5);
+      expect(await sft["balanceOf(address)"](user.address)).to.be.equal(2);
+      await user.sft.mergeValue(2, 1);
+      await user.sft.burn(2);
+      expect(await sft["balanceOf(address)"](user.address)).to.be.equal(1);
+
+      //fails: totalSupply is still 2
+      expect(await sft.totalSupply()).to.be.equal(1);
+    });
   });
 }


### PR DESCRIPTION
1 ERC3525.burn.ts
This is actually due to an non standard behaviour that's not hit when using the HyperCertMinter:burn logic. This prevents burning tokens by their owner if the owner is not the original minter of the slot ("claim") and all the token's fractions aren't fully merged. On behalf of the underlying ERC3525 standard I'd consider it natural, that token owners might consider burning them (instead of looking for an instance to return their tokens to for free, first). If we're burning an nft with value, the nft is gone and the value is gone, too, effectively lowering the total circulating "value supply" without further notice. That might be what we want but maybe... the value could also be returned to the claim / slot owner during the burning process.

2 ERC3525.mint.ts
tokenSupplyInSlot is part of the enumerable extension and part of the test suite I'm PRing against. However my test case demonstrates that the enumeration functions tokenInSlotByIndex and tokenSupplyInSlot fail / yield wrong values when called after an implicit value transfer to an address.

3 ERC3525.transfer.ts / HyperCertMinter.split.merge.ts
Both cases demonstrate the same unexpected behaviour on primitive level as well as on client level. The totalSupply of tokens doesn't decrease after value merges.
